### PR TITLE
add executable

### DIFF
--- a/parity.rb
+++ b/parity.rb
@@ -41,6 +41,7 @@ class Parity < Formula
         <integer>300</integer>
         <key>ProgramArguments</key>
         <array>
+          <string>#{prefix}/bin/parity</string>
         </array>
         <key>WorkingDirectory</key>
         <string>#{HOMEBREW_PREFIX}</string>


### PR DESCRIPTION
Am I missing something or does the plist lack the path to the executable?

Without this line `brew services start parity` aborts with `Invalid or missing Program/ProgramArguments` in 10.12 sierra.